### PR TITLE
Allow parsing of numbers with commas

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -147,7 +147,7 @@ const scrapeData = function (source: string) {
     table.find('.ace-paragraph-data').map(function (i, el) {
         const label = $('.ace-field-type', this).text().trim();
         const value = $('.ace-field-value', this).text().trim();
-        o[translate[label]] = parseInt(value);
+        o[translate[label]] = parseInt(value.replace(/,/g, ''), 10);
     });
 
     o["Updated"] = chrono.parseDate(date_updated).toISOString();


### PR DESCRIPTION
Right now the number parsing is failing on any number with a comma in it.

It's also a good idea to specify base 10 with parseInt to avoid any weird behavior with certain numbers.